### PR TITLE
tuple spreading

### DIFF
--- a/packages/sure/esm/array.d.ts
+++ b/packages/sure/esm/array.d.ts
@@ -1,2 +1,5 @@
 import { Sure, InferBad, InferGood, MetaNever, MetaObj } from './core.js';
-export declare function array<TPropFail, TPropGood, TSchema extends Sure<TPropFail, TPropGood, unknown, MetaObj | MetaNever>>(schema: TSchema): Sure<Array<InferBad<TSchema> | undefined>, Array<InferGood<TSchema>>, unknown, MetaObj<TSchema>>;
+export declare function array<TPropFail, TPropGood, TSchema extends Sure<TPropFail, TPropGood, unknown, MetaObj | MetaNever>>(schema: TSchema): Sure<Array<InferBad<TSchema> | undefined>, Array<InferGood<TSchema>>, unknown, MetaObj<{
+    parent: typeof array;
+    schema: TSchema;
+}>>;

--- a/packages/sure/esm/array.js
+++ b/packages/sure/esm/array.js
@@ -25,7 +25,10 @@ export function array(schema) {
             return bad(bads);
         }
         return good(goods);
-    }, schema);
+    }, {
+        parent: array,
+        schema,
+    });
     // @ts-expect-error Expected error
     return struct;
 }

--- a/packages/sure/esm/object.d.ts
+++ b/packages/sure/esm/object.d.ts
@@ -18,6 +18,10 @@ type PickNonOptionals<T extends KVPair<Sure>> = T extends {
 };
 export type InferSchemaGood<T extends Record<string, Sure>> = Prettify<Partial<Objectify<PickOptionalsGood<Unionize<T>>>> & Objectify<PickNonOptionals<Unionize<T>>>>;
 /**
+Necessary because `typeof x` is not a type guard.
+ */
+export declare function isObject(x: unknown): x is Record<string, unknown>;
+/**
  * Makes a object property `optional`
  * It doesn't make it nullable or undefinedable
  *

--- a/packages/sure/esm/object.js
+++ b/packages/sure/esm/object.js
@@ -2,7 +2,7 @@ import { sure, good, bad } from './core.js';
 /**
 Necessary because `typeof x` is not a type guard.
  */
-function isObject(x) {
+export function isObject(x) {
     return typeof x === 'object' && x !== null;
 }
 /**

--- a/packages/sure/esm/tuple.d.ts
+++ b/packages/sure/esm/tuple.d.ts
@@ -1,8 +1,34 @@
-import { MetaNever, MetaObj, Sure } from './core.js';
-export type TupleInferGoods<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<unknown, infer Good, any, MetaObj | MetaNever> ? [Good, ...TupleInferGoods<InferRest>] : [] : [];
-export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<infer Bad, unknown, any, MetaObj | MetaNever> ? [Bad | undefined, ...TupleInferBads<InferRest>] : [] : [];
-export declare function tupleRest<Arr extends Sure<unknown, unknown[], unknown>>(struct: Arr): Sure<unknown, unknown[], unknown, MetaObj<{
-    func: typeof tupleRest;
-    initial: unknown;
+import { InferBad, InferGood, MetaNever, MetaObj, Sure } from './core.js';
+export type TupleInferGoods_old<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<unknown, infer Good, any, MetaObj | MetaNever> ? [Good, ...TupleInferGoods<InferRest>] : [] : [];
+export type TupleInferGoods<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<unknown, infer Good, any, infer Meta> ? Meta extends MetaObj<{
+    parent: typeof spread_NOT_IMPLEMENTED;
+}> ? Good extends readonly unknown[] ? [...Good, ...TupleInferGoods<InferRest>] : [
+    Good,
+    ...TupleInferGoods<InferRest>
+] : [Good, ...TupleInferGoods<InferRest>] : [] : [];
+export type TupleInferBads_old<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<infer Bad, unknown, any, MetaObj | MetaNever> ? [Bad | undefined, ...TupleInferBads<InferRest>] : [] : [];
+export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferRest] ? First extends Sure<infer Bad, unknown, any, infer Meta> ? Meta extends MetaObj<{
+    parent: typeof spread_NOT_IMPLEMENTED;
+}> ? Bad extends readonly unknown[] ? [...Bad, ...TupleInferBads<InferRest>] : [
+    Bad | undefined,
+    ...TupleInferBads<InferRest>
+] : [Bad | undefined, ...TupleInferBads<InferRest>] : [] : [];
+/**
+ * @deprecated
+ *
+ * It's possible to add a spread operator.
+ * But it's seems that it would add a lot of complexity and will have to link the library too much.
+ *
+ * A tuple would have to know about both the spread and an array.
+ *
+ * It made sense for `object` and `optional`, since they're linked.
+ * But for tuples it can be more clearly implemented as a separate user-land function.
+ */
+export declare function spread_NOT_IMPLEMENTED<Arr extends Sure<unknown, unknown[], unknown>>(schema: Arr): Sure<InferBad<Arr>, InferGood<Arr>, unknown, MetaObj<{
+    parent: typeof spread_NOT_IMPLEMENTED;
+    schema: typeof schema;
 }>>;
-export declare function tuple<Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(arr: Arr): Sure<TupleInferBads<Arr>, TupleInferGoods<Arr>, unknown, MetaObj<Arr>>;
+export declare function tuple<Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(arr: Arr): Sure<TupleInferBads<Arr>, TupleInferGoods<Arr>, unknown, MetaObj<{
+    parent: typeof tuple;
+    schema: Arr;
+}>>;

--- a/packages/sure/esm/tuple.js
+++ b/packages/sure/esm/tuple.js
@@ -1,9 +1,12 @@
 import { bad, good, sure } from './core.js';
-export function tupleRest(struct) {
-    const val = sure(struct, {
-        func: tupleRest,
+import { isObject } from './object.js';
+export function spread(struct) {
+    // IMPORTANT: It's important to pass a new function here
+    const val = sure(value => struct(value), {
+        parent: spread,
         initial: struct.meta,
     });
+    // @ts-expect-error - this is fine
     return val;
 }
 export function tuple(arr) {
@@ -17,6 +20,9 @@ export function tuple(arr) {
         for (let i = 0; i < arr.length; i++) {
             // @ts-expect-error
             const elem = arr[i];
+            if (isObject(elem.meta) && elem.meta.parent === spread) {
+                // Iterathe through the elements until it doesn't work.
+            }
             const [good, unsure] = elem(value[i]);
             if (good) {
                 goods.push(unsure);
@@ -34,7 +40,11 @@ export function tuple(arr) {
             return bad(bads);
         }
         return good(goods);
-    }, arr);
+    }, {
+        parent: tuple,
+        initial: arr,
+    });
+    struct.meta;
     // @ts-expect-error
     return struct;
 }

--- a/packages/sure/esm/tuple.js
+++ b/packages/sure/esm/tuple.js
@@ -1,10 +1,20 @@
 import { bad, good, sure } from './core.js';
-import { isObject } from './object.js';
-export function spread(struct) {
+/**
+ * @deprecated
+ *
+ * It's possible to add a spread operator.
+ * But it's seems that it would add a lot of complexity and will have to link the library too much.
+ *
+ * A tuple would have to know about both the spread and an array.
+ *
+ * It made sense for `object` and `optional`, since they're linked.
+ * But for tuples it can be more clearly implemented as a separate user-land function.
+ */
+export function spread_NOT_IMPLEMENTED(schema) {
     // IMPORTANT: It's important to pass a new function here
-    const val = sure(value => struct(value), {
-        parent: spread,
-        initial: struct.meta,
+    const val = sure(value => schema(value), {
+        parent: spread_NOT_IMPLEMENTED,
+        schema,
     });
     // @ts-expect-error - this is fine
     return val;
@@ -20,9 +30,6 @@ export function tuple(arr) {
         for (let i = 0; i < arr.length; i++) {
             // @ts-expect-error
             const elem = arr[i];
-            if (isObject(elem.meta) && elem.meta.parent === spread) {
-                // Iterathe through the elements until it doesn't work.
-            }
             const [good, unsure] = elem(value[i]);
             if (good) {
                 goods.push(unsure);

--- a/packages/sure/src/__tests__/array.test.ts
+++ b/packages/sure/src/__tests__/array.test.ts
@@ -18,7 +18,11 @@ assertEqual<InferredInput, unknown>(true)
 assertEqual<
   InferredMeta,
   {
-    meta: Sure<'not number', number, unknown, MetaNever>
+    meta: {
+      parent: typeof array
+
+      schema: Sure<'not number', number, unknown, MetaNever>
+    }
   }
 >(true)
 

--- a/packages/sure/src/__tests__/learning/tuple_rest_stuff.ts
+++ b/packages/sure/src/__tests__/learning/tuple_rest_stuff.ts
@@ -1,0 +1,52 @@
+import { MetaObj, Sure, array, number, spread, string, tuple } from '../../index.js'
+
+// Doesn't work
+export type TupleInferGoods01<T> = //
+  T extends readonly [infer First, ...infer InferRest]
+    ? First extends Sure<unknown, infer Good, any, infer Meta>
+      ? Meta extends { parent: typeof spread }
+        ? // try spreading the rest if it's an array
+          Good extends readonly unknown[]
+          ? [...Good, ...TupleInferGoods01<InferRest>]
+          : // otherwise just return the good
+            [Good, ...TupleInferGoods01<InferRest>]
+        : [Good, ...TupleInferGoods01<InferRest>]
+      : []
+    : []
+
+const sample = [
+  //
+  string,
+  spread(array(number)),
+  string,
+] as const
+
+type Sample = typeof sample
+
+// [unknown[]]
+type Check01 = TupleInferGoods01<Sample>
+
+// ## Try fixing
+export type TupleInferGoods_02<T> = //
+  T extends readonly [infer First, ...infer InferRest]
+    ? First extends Sure<unknown, infer Good, any, infer Meta>
+      ? Meta extends MetaObj<{ parent: typeof spread }>
+        ? // try spreading the rest if it's an array
+          Good extends readonly unknown[]
+          ? [...Good, ...TupleInferGoods_02<InferRest>]
+          : // otherwise just return the good
+            [Good, ...TupleInferGoods_02<InferRest>]
+        : [Good, ...TupleInferGoods_02<InferRest>]
+      : []
+    : []
+
+// works
+type Check02 = TupleInferGoods_02<Sample>
+
+// Check for full tuple
+const schema = [
+  //
+  string,
+  spread(array(number)),
+  string,
+] as const

--- a/packages/sure/src/__tests__/learning/tuple_rest_stuff.ts
+++ b/packages/sure/src/__tests__/learning/tuple_rest_stuff.ts
@@ -1,10 +1,10 @@
-import { MetaObj, Sure, array, number, spread, string, tuple } from '../../index.js'
+import { MetaObj, Sure, array, number, spread_NOT_IMPLEMENTED, string, tuple } from '../../index.js'
 
 // Doesn't work
 export type TupleInferGoods01<T> = //
   T extends readonly [infer First, ...infer InferRest]
     ? First extends Sure<unknown, infer Good, any, infer Meta>
-      ? Meta extends { parent: typeof spread }
+      ? Meta extends { parent: typeof spread_NOT_IMPLEMENTED }
         ? // try spreading the rest if it's an array
           Good extends readonly unknown[]
           ? [...Good, ...TupleInferGoods01<InferRest>]
@@ -17,7 +17,7 @@ export type TupleInferGoods01<T> = //
 const sample = [
   //
   string,
-  spread(array(number)),
+  spread_NOT_IMPLEMENTED(array(number)),
   string,
 ] as const
 
@@ -30,7 +30,7 @@ type Check01 = TupleInferGoods01<Sample>
 export type TupleInferGoods_02<T> = //
   T extends readonly [infer First, ...infer InferRest]
     ? First extends Sure<unknown, infer Good, any, infer Meta>
-      ? Meta extends MetaObj<{ parent: typeof spread }>
+      ? Meta extends MetaObj<{ parent: typeof spread_NOT_IMPLEMENTED }>
         ? // try spreading the rest if it's an array
           Good extends readonly unknown[]
           ? [...Good, ...TupleInferGoods_02<InferRest>]
@@ -47,6 +47,6 @@ type Check02 = TupleInferGoods_02<Sample>
 const schema = [
   //
   string,
-  spread(array(number)),
+  spread_NOT_IMPLEMENTED(array(number)),
   string,
 ] as const

--- a/packages/sure/src/__tests__/tuple.test.ts
+++ b/packages/sure/src/__tests__/tuple.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, assert } from 'vitest'
-import { tuple, number, string, boolean, good, bad, spread, array, nil, undef } from '../index.js'
+import { tuple, number, string, boolean, good, bad, spread_NOT_IMPLEMENTED, array, nil, undef } from '../index.js'
 import type {
   InferGood,
   InferBad,
@@ -45,7 +45,7 @@ const someTuple = tuple([number, string, boolean])
 const myTuple = tuple([
   //
   string,
-  spread(array(number)),
+  spread_NOT_IMPLEMENTED(array(number)),
   string,
 ])
 
@@ -96,7 +96,7 @@ const myTuple = tuple([
               InferGood<Arr>,
               unknown,
               MetaObj<{
-                parent: typeof spread
+                parent: typeof spread_NOT_IMPLEMENTED
                 schema: Arr
               }>
             >
@@ -134,7 +134,7 @@ const myTuple = tuple([
 const smallSchema = tuple([
   //
   undef,
-  spread(array(string)),
+  spread_NOT_IMPLEMENTED(array(string)),
   number,
 ])
 
@@ -185,7 +185,7 @@ const smallSchema = tuple([
               InferGood<Arr>,
               unknown,
               MetaObj<{
-                parent: typeof spread
+                parent: typeof spread_NOT_IMPLEMENTED
                 schema: Arr
               }>
             >
@@ -220,7 +220,7 @@ const smallSchema = tuple([
   >(true)
 }
 
-describe('array', () => {
+describe('tuple', () => {
   it('should return good value', () => {
     const value = someTuple([1, 'hello', true])
 
@@ -241,7 +241,7 @@ describe('array', () => {
     const arrSchema = [
       //
       string,
-      spread(array(number)),
+      spread_NOT_IMPLEMENTED(array(number)),
     ] as const
 
     type InferSchema = TupleInferGoods<typeof arrSchema>
@@ -253,7 +253,7 @@ describe('array', () => {
     const arrSchema = [
       //
       string,
-      spread(array(number)),
+      spread_NOT_IMPLEMENTED(array(number)),
       string,
     ] as const
 
@@ -262,7 +262,7 @@ describe('array', () => {
     const schema = tuple([
       //
       string,
-      spread(array(number)),
+      spread_NOT_IMPLEMENTED(array(number)),
       string,
     ])
 
@@ -275,11 +275,11 @@ describe('array', () => {
     const schema = tuple([
       //
       string,
-      spread(array(number)),
+      spread_NOT_IMPLEMENTED(array(number)),
 
       nil,
 
-      spread(smallSchema),
+      spread_NOT_IMPLEMENTED(smallSchema),
     ])
 
     type InferredGood = InferGood<typeof schema>
@@ -294,7 +294,7 @@ describe('array', () => {
     const smallSchema = tuple([
       //
       undef,
-      spread(array(string)),
+      spread_NOT_IMPLEMENTED(array(string)),
       number,
     ])
 

--- a/packages/sure/src/__tests__/tuple.test.ts
+++ b/packages/sure/src/__tests__/tuple.test.ts
@@ -34,7 +34,7 @@ const someTuple = tuple([number, string, boolean])
         parent: typeof tuple
         schema: [
           Sure<'not number', number, unknown, MetaNever>,
-          Sure<'not string', string, unknown, MetaObj<undefined>>,
+          typeof string,
           (x: unknown) => Good<boolean> | Bad<'not boolean'>,
         ]
       }
@@ -57,29 +57,61 @@ const spreadedTuple = tuple([number, spread(array(string)), boolean])
     InferredMeta,
     {
       meta: {
-        parent: typeof tuple
+        parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
+          arr: Arr
+        ) => Sure<
+          TupleInferBads<Arr>,
+          TupleInferGoods<Arr>,
+          unknown,
+          MetaObj<{
+            parent: typeof tuple
+            schema: Arr
+          }>
+        >
         schema: [
-          typeof number,
+          Sure<'not number', number, unknown, MetaNever>,
           Sure<
             ('not string' | undefined)[],
             string[],
             unknown,
             MetaObj<{
               parent: <Arr extends Sure<unknown, unknown[], unknown>>(
-                struct: Arr
+                schema: Arr
               ) => Sure<
                 InferBad<Arr>,
                 InferGood<Arr>,
                 unknown,
                 MetaObj<{
                   parent: typeof spread
-                  initial: unknown
+                  schema: Arr
                 }>
               >
-              initial: unknown
+              schema: Sure<
+                ('not string' | undefined)[],
+                string[],
+                unknown,
+                MetaObj<{
+                  parent: <
+                    TPropFail,
+                    TPropGood,
+                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
+                  >(
+                    schema: TSchema
+                  ) => Sure<
+                    (InferBad<TSchema> | undefined)[],
+                    InferGood<TSchema>[],
+                    unknown,
+                    MetaObj<{
+                      parent: typeof array
+                      schema: TSchema
+                    }>
+                  >
+                  schema: typeof string
+                }>
+              >
             }>
           >,
-          typeof boolean,
+          (x: unknown) => Good<boolean> | Bad<'not boolean'>,
         ]
       }
     }
@@ -144,19 +176,61 @@ describe('array', () => {
     assertEqual<
       InferredMeta,
       MetaObj<{
-        parent: typeof tuple
+        parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
+          arr: Arr
+        ) => Sure<
+          TupleInferBads<Arr>,
+          TupleInferGoods<Arr>,
+          unknown,
+          MetaObj<{
+            parent: typeof tuple
+            schema: Arr
+          }>
+        >
         schema: [
-          Sure<'not string', string, unknown, MetaObj<undefined>>,
+          typeof string,
           Sure<
             ('not number' | undefined)[],
             number[],
             unknown,
             MetaObj<{
-              parent: typeof spread
-              initial: unknown
+              parent: <Arr extends Sure<unknown, unknown[], unknown>>(
+                schema: Arr
+              ) => Sure<
+                InferBad<Arr>,
+                InferGood<Arr>,
+                unknown,
+                MetaObj<{
+                  parent: typeof spread
+                  schema: Arr
+                }>
+              >
+              schema: Sure<
+                ('not number' | undefined)[],
+                number[],
+                unknown,
+                MetaObj<{
+                  parent: <
+                    TPropFail,
+                    TPropGood,
+                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
+                  >(
+                    schema: TSchema
+                  ) => Sure<
+                    (InferBad<TSchema> | undefined)[],
+                    InferGood<TSchema>[],
+                    unknown,
+                    MetaObj<{
+                      parent: typeof array
+                      schema: TSchema
+                    }>
+                  >
+                  schema: Sure<'not number', number, unknown, MetaNever>
+                }>
+              >
             }>
           >,
-          Sure<'not string', string, unknown, MetaObj<undefined>>,
+          typeof string,
         ]
       }>
     >(true)
@@ -232,17 +306,39 @@ describe('array', () => {
             unknown,
             MetaObj<{
               parent: <Arr extends Sure<unknown, unknown[], unknown>>(
-                struct: Arr
+                schema: Arr
               ) => Sure<
                 InferBad<Arr>,
                 InferGood<Arr>,
                 unknown,
                 MetaObj<{
                   parent: typeof spread
-                  initial: unknown
+                  schema: Arr
                 }>
               >
-              initial: unknown
+              schema: Sure<
+                ('not string' | undefined)[],
+                string[],
+                unknown,
+                MetaObj<{
+                  parent: <
+                    TPropFail,
+                    TPropGood,
+                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
+                  >(
+                    schema: TSchema
+                  ) => Sure<
+                    (InferBad<TSchema> | undefined)[],
+                    InferGood<TSchema>[],
+                    unknown,
+                    MetaObj<{
+                      parent: typeof array
+                      schema: TSchema
+                    }>
+                  >
+                  schema: typeof string
+                }>
+              >
             }>
           >,
           Sure<'not number', number, unknown, MetaNever>,

--- a/packages/sure/src/__tests__/tuple.test.ts
+++ b/packages/sure/src/__tests__/tuple.test.ts
@@ -42,79 +42,181 @@ const someTuple = tuple([number, string, boolean])
   >(true)
 }
 
-const spreadedTuple = tuple([number, spread(array(string)), boolean])
+const myTuple = tuple([
+  //
+  string,
+  spread(array(number)),
+  string,
+])
 
 {
-  type InferredGood = InferGood<typeof spreadedTuple>
-  type InferredBad = InferBad<typeof spreadedTuple>
-  type InferredInput = InferInput<typeof spreadedTuple>
-  type InferredMeta = InferMeta<typeof spreadedTuple>
+  type InferredGood = InferGood<typeof myTuple>
+  type InferredBad = InferBad<typeof myTuple>
+  type InferredInput = InferInput<typeof myTuple>
+  type InferredMeta = InferMeta<typeof myTuple>
 
   assertEqual<InferredInput, unknown>(true)
-  assertEqual<InferredGood, [number, ...string[], boolean]>(true)
-  assertEqual<InferredBad, ['not number' | undefined, ...('not string' | undefined)[], 'not boolean' | undefined]>(true)
+
+  assertEqual<InferredGood, [string, ...number[], string]>(true)
+  assertEqual<
+    InferredBad,
+    [
+      //
+      'not string' | undefined,
+      ...('not number' | undefined)[],
+      'not string' | undefined,
+    ]
+  >(true)
+
   assertEqual<
     InferredMeta,
-    {
-      meta: {
-        parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
-          arr: Arr
-        ) => Sure<
-          TupleInferBads<Arr>,
-          TupleInferGoods<Arr>,
+    MetaObj<{
+      parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
+        arr: Arr
+      ) => Sure<
+        TupleInferBads<Arr>,
+        TupleInferGoods<Arr>,
+        unknown,
+        MetaObj<{
+          parent: typeof tuple
+          schema: Arr
+        }>
+      >
+      schema: [
+        typeof string,
+        Sure<
+          ('not number' | undefined)[],
+          number[],
           unknown,
           MetaObj<{
-            parent: typeof tuple
-            schema: Arr
-          }>
-        >
-        schema: [
-          Sure<'not number', number, unknown, MetaNever>,
-          Sure<
-            ('not string' | undefined)[],
-            string[],
-            unknown,
-            MetaObj<{
-              parent: <Arr extends Sure<unknown, unknown[], unknown>>(
+            parent: <Arr extends Sure<unknown, unknown[], unknown>>(
+              schema: Arr
+            ) => Sure<
+              InferBad<Arr>,
+              InferGood<Arr>,
+              unknown,
+              MetaObj<{
+                parent: typeof spread
                 schema: Arr
-              ) => Sure<
-                InferBad<Arr>,
-                InferGood<Arr>,
-                unknown,
-                MetaObj<{
-                  parent: typeof spread
-                  schema: Arr
-                }>
-              >
-              schema: Sure<
-                ('not string' | undefined)[],
-                string[],
-                unknown,
-                MetaObj<{
-                  parent: <
-                    TPropFail,
-                    TPropGood,
-                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
-                  >(
+              }>
+            >
+            schema: Sure<
+              ('not number' | undefined)[],
+              number[],
+              unknown,
+              MetaObj<{
+                parent: <
+                  TPropFail,
+                  TPropGood,
+                  TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
+                >(
+                  schema: TSchema
+                ) => Sure<
+                  (InferBad<TSchema> | undefined)[],
+                  InferGood<TSchema>[],
+                  unknown,
+                  MetaObj<{
+                    parent: typeof array
                     schema: TSchema
-                  ) => Sure<
-                    (InferBad<TSchema> | undefined)[],
-                    InferGood<TSchema>[],
-                    unknown,
-                    MetaObj<{
-                      parent: typeof array
-                      schema: TSchema
-                    }>
-                  >
-                  schema: typeof string
-                }>
-              >
-            }>
-          >,
-          (x: unknown) => Good<boolean> | Bad<'not boolean'>,
-        ]
-      }
-    }
+                  }>
+                >
+                schema: Sure<'not number', number, unknown, MetaNever>
+              }>
+            >
+          }>
+        >,
+        typeof string,
+      ]
+    }>
+  >(true)
+}
+
+const smallSchema = tuple([
+  //
+  undef,
+  spread(array(string)),
+  number,
+])
+
+{
+  type InferredGood = InferGood<typeof smallSchema>
+  type InferredBad = InferBad<typeof smallSchema>
+  type InferredInput = InferInput<typeof smallSchema>
+  type InferredMeta = InferMeta<typeof smallSchema>
+
+  assertEqual<InferredInput, unknown>(true)
+
+  assertEqual<InferredGood, [undefined, ...string[], number]>(true)
+  assertEqual<
+    InferredBad,
+    [
+      //
+      'not undefined' | undefined,
+      ...('not string' | undefined)[],
+      'not number' | undefined,
+    ]
+  >(true)
+
+  assertEqual<
+    InferredMeta,
+    MetaObj<{
+      parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
+        arr: Arr
+      ) => Sure<
+        TupleInferBads<Arr>,
+        TupleInferGoods<Arr>,
+        unknown,
+        MetaObj<{
+          parent: typeof tuple
+          schema: Arr
+        }>
+      >
+      schema: [
+        (value: unknown) => Good<undefined> | Bad<'not undefined'>,
+        Sure<
+          ('not string' | undefined)[],
+          string[],
+          unknown,
+          MetaObj<{
+            parent: <Arr extends Sure<unknown, unknown[], unknown>>(
+              schema: Arr
+            ) => Sure<
+              InferBad<Arr>,
+              InferGood<Arr>,
+              unknown,
+              MetaObj<{
+                parent: typeof spread
+                schema: Arr
+              }>
+            >
+            schema: Sure<
+              ('not string' | undefined)[],
+              string[],
+              unknown,
+              MetaObj<{
+                parent: <
+                  TPropFail,
+                  TPropGood,
+                  TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
+                >(
+                  schema: TSchema
+                ) => Sure<
+                  (InferBad<TSchema> | undefined)[],
+                  InferGood<TSchema>[],
+                  unknown,
+                  MetaObj<{
+                    parent: typeof array
+                    schema: TSchema
+                  }>
+                >
+                schema: typeof string
+              }>
+            >
+          }>
+        >,
+        Sure<'not number', number, unknown, MetaNever>,
+      ]
+    }>
   >(true)
 }
 
@@ -147,95 +249,6 @@ describe('array', () => {
     assertEqual<InferSchema, [string, ...number[], string]>(true)
   })
 
-  it('DX: should type well', () => {
-    const myTuple = tuple([
-      //
-      string,
-      spread(array(number)),
-      string,
-    ])
-
-    type InferredGood = InferGood<typeof myTuple>
-    type InferredBad = InferBad<typeof myTuple>
-    type InferredInput = InferInput<typeof myTuple>
-    type InferredMeta = InferMeta<typeof myTuple>
-
-    assertEqual<InferredInput, unknown>(true)
-
-    assertEqual<InferredGood, [string, ...number[], string]>(true)
-    assertEqual<
-      InferredBad,
-      [
-        //
-        'not string' | undefined,
-        ...('not number' | undefined)[],
-        'not string' | undefined,
-      ]
-    >(true)
-
-    assertEqual<
-      InferredMeta,
-      MetaObj<{
-        parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
-          arr: Arr
-        ) => Sure<
-          TupleInferBads<Arr>,
-          TupleInferGoods<Arr>,
-          unknown,
-          MetaObj<{
-            parent: typeof tuple
-            schema: Arr
-          }>
-        >
-        schema: [
-          typeof string,
-          Sure<
-            ('not number' | undefined)[],
-            number[],
-            unknown,
-            MetaObj<{
-              parent: <Arr extends Sure<unknown, unknown[], unknown>>(
-                schema: Arr
-              ) => Sure<
-                InferBad<Arr>,
-                InferGood<Arr>,
-                unknown,
-                MetaObj<{
-                  parent: typeof spread
-                  schema: Arr
-                }>
-              >
-              schema: Sure<
-                ('not number' | undefined)[],
-                number[],
-                unknown,
-                MetaObj<{
-                  parent: <
-                    TPropFail,
-                    TPropGood,
-                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
-                  >(
-                    schema: TSchema
-                  ) => Sure<
-                    (InferBad<TSchema> | undefined)[],
-                    InferGood<TSchema>[],
-                    unknown,
-                    MetaObj<{
-                      parent: typeof array
-                      schema: TSchema
-                    }>
-                  >
-                  schema: Sure<'not number', number, unknown, MetaNever>
-                }>
-              >
-            }>
-          >,
-          typeof string,
-        ]
-      }>
-    >(true)
-  })
-
   it('DX: should allow spread tuples', () => {
     const arrSchema = [
       //
@@ -258,94 +271,7 @@ describe('array', () => {
     assertEqual<InferredGood, [string, ...number[], string]>(true)
   })
 
-  it('more complex', () => {
-    const smallSchema = tuple([
-      //
-      undef,
-      spread(array(string)),
-      number,
-    ])
-
-    type InferGood_01 = InferGood<typeof smallSchema>
-    type InferBad_01 = InferBad<typeof smallSchema>
-    type InferInput_01 = InferInput<typeof smallSchema>
-    type InferMeta_01 = InferMeta<typeof smallSchema>
-
-    assertEqual<InferInput_01, unknown>(true)
-
-    assertEqual<InferGood_01, [undefined, ...string[], number]>(true)
-    assertEqual<
-      InferBad_01,
-      [
-        //
-        'not undefined' | undefined,
-        ...('not string' | undefined)[],
-        'not number' | undefined,
-      ]
-    >(true)
-
-    assertEqual<
-      InferMeta_01,
-      MetaObj<{
-        parent: <Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown, unknown, any>[]] | []>(
-          arr: Arr
-        ) => Sure<
-          TupleInferBads<Arr>,
-          TupleInferGoods<Arr>,
-          unknown,
-          MetaObj<{
-            parent: typeof tuple
-            schema: Arr
-          }>
-        >
-        schema: [
-          (value: unknown) => Good<undefined> | Bad<'not undefined'>,
-          Sure<
-            ('not string' | undefined)[],
-            string[],
-            unknown,
-            MetaObj<{
-              parent: <Arr extends Sure<unknown, unknown[], unknown>>(
-                schema: Arr
-              ) => Sure<
-                InferBad<Arr>,
-                InferGood<Arr>,
-                unknown,
-                MetaObj<{
-                  parent: typeof spread
-                  schema: Arr
-                }>
-              >
-              schema: Sure<
-                ('not string' | undefined)[],
-                string[],
-                unknown,
-                MetaObj<{
-                  parent: <
-                    TPropFail,
-                    TPropGood,
-                    TSchema extends Sure<TPropFail, TPropGood, unknown, MetaNever | MetaObj>,
-                  >(
-                    schema: TSchema
-                  ) => Sure<
-                    (InferBad<TSchema> | undefined)[],
-                    InferGood<TSchema>[],
-                    unknown,
-                    MetaObj<{
-                      parent: typeof array
-                      schema: TSchema
-                    }>
-                  >
-                  schema: typeof string
-                }>
-              >
-            }>
-          >,
-          Sure<'not number', number, unknown, MetaNever>,
-        ]
-      }>
-    >(true)
-
+  it('ISSUE: Typescript does not allow multiple rest operators in a tuple', () => {
     const schema = tuple([
       //
       string,
@@ -357,7 +283,6 @@ describe('array', () => {
     ])
 
     type InferredGood = InferGood<typeof schema>
-    type InferredBad = InferBad<typeof schema>
 
     assertEqual<InferredGood, [string, ...number[], null, ...[undefined, ...string[], number]]>(true)
 

--- a/packages/sure/src/array.ts
+++ b/packages/sure/src/array.ts
@@ -12,39 +12,50 @@ export function array<
   Array<InferBad<TSchema> | undefined>,
   Array<InferGood<TSchema>>,
   unknown,
-  MetaObj<TSchema>
+  MetaObj<{
+    parent: typeof array
+
+    schema: TSchema
+  }>
 > {
-  const struct = sure(value => {
-    if (!Array.isArray(value)) {
-      return bad([])
-    }
-
-    let atLeastOneBad = false
-    let bads = []
-    let goods = []
-
-    for (const elem of value) {
-      const [good, unsure] = schema(elem)
-
-      if (good) {
-        goods.push(unsure)
-        // This is necessary in order to maintain the same length
-        bads.push(undefined)
-      } else {
-        bads.push(unsure)
-
-        // Since the `bads` array can containe `undefined` values, it's more clear to
-        // have an imperative boolean to make the check
-        atLeastOneBad = true
+  const struct = sure(
+    value => {
+      if (!Array.isArray(value)) {
+        return bad([])
       }
-    }
 
-    if (atLeastOneBad) {
-      return bad(bads)
-    }
+      let atLeastOneBad = false
+      let bads = []
+      let goods = []
 
-    return good(goods)
-  }, schema)
+      for (const elem of value) {
+        const [good, unsure] = schema(elem)
+
+        if (good) {
+          goods.push(unsure)
+          // This is necessary in order to maintain the same length
+          bads.push(undefined)
+        } else {
+          bads.push(unsure)
+
+          // Since the `bads` array can containe `undefined` values, it's more clear to
+          // have an imperative boolean to make the check
+          atLeastOneBad = true
+        }
+      }
+
+      if (atLeastOneBad) {
+        return bad(bads)
+      }
+
+      return good(goods)
+    },
+    {
+      parent: array,
+
+      schema,
+    }
+  )
 
   // @ts-expect-error Expected error
   return struct

--- a/packages/sure/src/object.ts
+++ b/packages/sure/src/object.ts
@@ -35,7 +35,7 @@ export type InferSchemaGood<T extends Record<string, Sure>> = Prettify<
 /**
 Necessary because `typeof x` is not a type guard.
  */
-function isObject(x: unknown): x is Record<string, unknown> {
+export function isObject(x: unknown): x is Record<string, unknown> {
   return typeof x === 'object' && x !== null
 }
 

--- a/packages/sure/src/tuple.ts
+++ b/packages/sure/src/tuple.ts
@@ -12,7 +12,7 @@ export type TupleInferGoods_old<T> = T extends readonly [infer First, ...infer I
 export type TupleInferGoods<T> = //
   T extends readonly [infer First, ...infer InferRest]
     ? First extends Sure<unknown, infer Good, any, infer Meta>
-      ? Meta extends MetaObj<{ parent: typeof spread }>
+      ? Meta extends MetaObj<{ parent: typeof spread_NOT_IMPLEMENTED }>
         ? // try spreading the rest if it's an array
           Good extends readonly unknown[]
           ? [...Good, ...TupleInferGoods<InferRest>]
@@ -30,7 +30,7 @@ export type TupleInferBads_old<T> = T extends readonly [infer First, ...infer In
 
 export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferRest]
   ? First extends Sure<infer Bad, unknown, any, infer Meta>
-    ? Meta extends MetaObj<{ parent: typeof spread }>
+    ? Meta extends MetaObj<{ parent: typeof spread_NOT_IMPLEMENTED }>
       ? // try spreading the rest if it's an array
         Bad extends readonly unknown[]
         ? [...Bad, ...TupleInferBads<InferRest>]
@@ -40,20 +40,31 @@ export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferR
     : []
   : []
 
-export function spread<Arr extends Sure<unknown, unknown[], unknown>>(
+/**
+ * @deprecated
+ *
+ * It's possible to add a spread operator.
+ * But it's seems that it would add a lot of complexity and will have to link the library too much.
+ *
+ * A tuple would have to know about both the spread and an array.
+ *
+ * It made sense for `object` and `optional`, since they're linked.
+ * But for tuples it can be more clearly implemented as a separate user-land function.
+ */
+export function spread_NOT_IMPLEMENTED<Arr extends Sure<unknown, unknown[], unknown>>(
   schema: Arr
 ): Sure<
   InferBad<Arr>,
   InferGood<Arr>,
   unknown,
   MetaObj<{
-    parent: typeof spread
+    parent: typeof spread_NOT_IMPLEMENTED
     schema: typeof schema
   }>
 > {
   // IMPORTANT: It's important to pass a new function here
   const val = sure(value => schema(value), {
-    parent: spread,
+    parent: spread_NOT_IMPLEMENTED,
     schema,
   })
 
@@ -87,10 +98,6 @@ export function tuple<Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown,
       for (let i = 0; i < arr.length; i++) {
         // @ts-expect-error
         const elem: Sure<unknown, unknown, any> = arr[i]
-
-        if (isObject(elem.meta) && elem.meta.parent === spread) {
-          // Iterathe through the elements until it doesn't work.
-        }
 
         const [good, unsure] = elem(value[i])
 

--- a/packages/sure/src/tuple.ts
+++ b/packages/sure/src/tuple.ts
@@ -1,25 +1,64 @@
-import { MetaNever, MetaObj, Sure, bad, good, sure } from './core.js'
+import { InferBad, InferGood, MetaNever, MetaObj, Sure, bad, good, sure } from './core.js'
+import { isObject } from './object.js'
 
 // TODO: add tests, also implement tuple spread
-export type TupleInferGoods<T> = T extends readonly [infer First, ...infer InferRest]
+export type TupleInferGoods_old<T> = T extends readonly [infer First, ...infer InferRest]
   ? First extends Sure<unknown, infer Good, any, MetaObj | MetaNever>
     ? [Good, ...TupleInferGoods<InferRest>]
     : []
   : []
 
-export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferRest]
+// Add test
+export type TupleInferGoods<T> = //
+  T extends readonly [infer First, ...infer InferRest]
+    ? First extends Sure<unknown, infer Good, any, infer Meta>
+      ? Meta extends MetaObj<{ parent: typeof spread }>
+        ? // try spreading the rest if it's an array
+          Good extends readonly unknown[]
+          ? [...Good, ...TupleInferGoods<InferRest>]
+          : // otherwise just return the good
+            [Good, ...TupleInferGoods<InferRest>]
+        : [Good, ...TupleInferGoods<InferRest>]
+      : []
+    : []
+
+export type TupleInferBads_old<T> = T extends readonly [infer First, ...infer InferRest]
   ? First extends Sure<infer Bad, unknown, any, MetaObj | MetaNever>
     ? [Bad | undefined, ...TupleInferBads<InferRest>]
     : []
   : []
 
-export function tupleRest<Arr extends Sure<unknown, unknown[], unknown>>(struct: Arr) {
-  const val = sure(struct, {
-    func: tupleRest,
+export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferRest]
+  ? First extends Sure<infer Bad, unknown, any, infer Meta>
+    ? Meta extends MetaObj<{ parent: typeof spread }>
+      ? // try spreading the rest if it's an array
+        Bad extends readonly unknown[]
+        ? [...Bad, ...TupleInferBads<InferRest>]
+        : // otherwise just return the bad
+          [Bad | undefined, ...TupleInferBads<InferRest>]
+      : [Bad | undefined, ...TupleInferBads<InferRest>]
+    : []
+  : []
+
+export function spread<Arr extends Sure<unknown, unknown[], unknown>>(
+  struct: Arr
+): Sure<
+  InferBad<Arr>,
+  InferGood<Arr>,
+  unknown,
+  MetaObj<{
+    parent: typeof spread
+    initial: unknown
+  }>
+> {
+  // IMPORTANT: It's important to pass a new function here
+  const val = sure(value => struct(value), {
+    parent: spread,
 
     initial: struct.meta,
   })
 
+  // @ts-expect-error - this is fine
   return val
 }
 
@@ -30,42 +69,59 @@ export function tuple<Arr extends [Sure<unknown, unknown, any>, ...Sure<unknown,
   TupleInferBads<Arr>,
   TupleInferGoods<Arr>,
   unknown,
-  MetaObj<Arr>
+  MetaObj<{
+    parent: typeof tuple
+
+    schema: Arr
+  }>
 > {
-  const struct = sure(value => {
-    if (!Array.isArray(value)) {
-      return bad([])
-    }
-
-    let atLeastOneBad = false
-    let bads = []
-    let goods = []
-
-    for (let i = 0; i < arr.length; i++) {
-      // @ts-expect-error
-      const elem: Sure<unknown, unknown, any> = arr[i]
-
-      const [good, unsure] = elem(value[i])
-
-      if (good) {
-        goods.push(unsure)
-        // This is necessary in order to maintain the same length
-        bads.push(undefined)
-      } else {
-        bads.push(unsure)
-
-        // Since the `bads` array can containe `undefined` values, it's more clear to
-        // have an imperative boolean to make the check
-        atLeastOneBad = true
+  const struct = sure(
+    value => {
+      if (!Array.isArray(value)) {
+        return bad([])
       }
-    }
 
-    if (atLeastOneBad) {
-      return bad(bads)
-    }
+      let atLeastOneBad = false
+      let bads = []
+      let goods = []
 
-    return good(goods)
-  }, arr)
+      for (let i = 0; i < arr.length; i++) {
+        // @ts-expect-error
+        const elem: Sure<unknown, unknown, any> = arr[i]
+
+        if (isObject(elem.meta) && elem.meta.parent === spread) {
+          // Iterathe through the elements until it doesn't work.
+        }
+
+        const [good, unsure] = elem(value[i])
+
+        if (good) {
+          goods.push(unsure)
+          // This is necessary in order to maintain the same length
+          bads.push(undefined)
+        } else {
+          bads.push(unsure)
+
+          // Since the `bads` array can containe `undefined` values, it's more clear to
+          // have an imperative boolean to make the check
+          atLeastOneBad = true
+        }
+      }
+
+      if (atLeastOneBad) {
+        return bad(bads)
+      }
+
+      return good(goods)
+    },
+    {
+      parent: tuple,
+
+      initial: arr,
+    }
+  )
+
+  struct.meta
 
   // @ts-expect-error
   return struct

--- a/packages/sure/src/tuple.ts
+++ b/packages/sure/src/tuple.ts
@@ -41,21 +41,20 @@ export type TupleInferBads<T> = T extends readonly [infer First, ...infer InferR
   : []
 
 export function spread<Arr extends Sure<unknown, unknown[], unknown>>(
-  struct: Arr
+  schema: Arr
 ): Sure<
   InferBad<Arr>,
   InferGood<Arr>,
   unknown,
   MetaObj<{
     parent: typeof spread
-    initial: unknown
+    schema: typeof schema
   }>
 > {
   // IMPORTANT: It's important to pass a new function here
-  const val = sure(value => struct(value), {
+  const val = sure(value => schema(value), {
     parent: spread,
-
-    initial: struct.meta,
+    schema,
   })
 
   // @ts-expect-error - this is fine


### PR DESCRIPTION
I've managed to implement the type definition for using something like:

```ts
tuple([
  string,
  spread(array(number)),
  boolean
])
```

but it seems that the added complexity would go against the direction of the simplicity of the library.

The structure above can be implemented for specific use-cases like this:
```ts
const mSchema = after(array, val => {
   // check here if first element is string and the last is boolean
   // and the ones in the middle are numbers.

  // use some type assertion (not type-safe, but ok) and return
})
```

This idea can be changed if the need arises afterwards.